### PR TITLE
Fix bug in pack updating

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -298,6 +298,8 @@ if [ "$UPDATE_PACKS" = "update" ] && [ "$CMD" != "stop" ]; then
     if [ "$UPDATE_STAGING" = "staging" ]; then
         export WSO2_UPDATES_UPDATE_LEVEL_STATE=TESTING
         echo "Updating packs to staging (TESTING level)..."
+    else
+        unset WSO2_UPDATES_UPDATE_LEVEL_STATE
     fi
 
     update_packs


### PR DESCRIPTION
This pull request makes a minor improvement to the `run.sh` script by ensuring that the `WSO2_UPDATES_UPDATE_LEVEL_STATE` environment variable is unset when not updating packs to the staging (TESTING) level. This prevents updating the pack to staging when it is unintended (using only `--update`). 